### PR TITLE
fix: restore chess piece centering and move board border

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ tsconfig.tsbuildinfo
 
 # Reference code (not tracked - local only)
 maia-platform-frontend/
+conductor.json

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -124,6 +124,8 @@ cg-board piece {
   height: 12.5%;
   /* Piece images as backgrounds */
   background-size: cover;
+  /* Center the piece image within the square */
+  background-position: center;
   /* Prevent selection */
   pointer-events: none;
   /* Layer above board */
@@ -772,6 +774,12 @@ cg-board {
     #F0D9B5 270deg
   );
   background-size: 25% 25%;
+  /* NOTE: Do NOT add border here - it breaks chessground's piece positioning
+     due to box-sizing: border-box. Border is on .board-container instead. */
+}
+
+/* Board container gets the border to avoid breaking chessground internals */
+.board-container {
   border: var(--border-thick) solid var(--color-border-strong);
 }
 


### PR DESCRIPTION
## Summary
Fixes misaligned chess pieces in the bottom-right of squares caused by missing piece centering CSS and a border on cg-board that interfered with chessground's coordinate system.

## Changes
- Restore `background-position: center` on chess pieces (removed in 759cfd4)
- Move board border from `cg-board` to `.board-container` to avoid breaking piece positioning due to `box-sizing: border-box`
- Add explanatory comments to prevent regression

## Testing
All 141 E2E tests pass. Visual inspection confirms pieces are now centered in their squares.