### PR TITLE
feat: add conductor scripts for dev server and cleanup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "setup": "npm install",
+    "run": "PORT=$CONDUCTOR_PORT npm run dev",
+    "archive": "pkill -f 'next dev' || true; pkill -f 'playwright' || true; pkill -f 'chromium' || true"
+  },
+  "runScriptMode": "nonconcurrent"
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,8 +57,9 @@ export default defineConfig({
      * Base URL for page.goto() calls.
      * This means we can write page.goto('/analysis') instead of
      * page.goto('http://localhost:3000/analysis')
+     * Uses CONDUCTOR_PORT if set, otherwise defaults to 3000.
      */
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${process.env.CONDUCTOR_PORT || 3000}`,
 
     /**
      * Collect trace when retrying a failed test.
@@ -100,10 +101,12 @@ export default defineConfig({
    *
    * The reuseExistingServer option means if you already have a dev server
    * running, Playwright will use that instead of starting a new one.
+   *
+   * Uses CONDUCTOR_PORT if set, otherwise defaults to 3000.
    */
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    command: `PORT=${process.env.CONDUCTOR_PORT || 3000} npm run dev`,
+    url: `http://localhost:${process.env.CONDUCTOR_PORT || 3000}`,
     reuseExistingServer: !process.env.CI,
     // Wait up to 2 minutes for the server to start
     timeout: 120000,


### PR DESCRIPTION
Add conductor.json with setup, run, and archive scripts for Conductor integration:

- **setup**: Install npm dependencies when workspace is created
- **run**: Start Next.js dev server on dynamically assigned CONDUCTOR_PORT
- **archive**: Kill orphaned dev servers and Playwright processes on workspace deletion

Update Playwright config to respect CONDUCTOR_PORT environment variable for dynamic port assignment.